### PR TITLE
Harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,13 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     container:
       image: debian:bookworm
     steps:
@@ -23,53 +24,60 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure git safe directory
         run: git config --global --add safe.directory $(pwd)
 
+      - name: Import Public Key
+        run: |
+          printf '%s\n' "$GPG_PUBLIC_KEY" | gpg --import
+        env:
+          GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+
+      - name: Verify Signature
+        run: |
+          if ! git verify-tag -- "$TAG_NAME"; then
+            echo "Error: Tag is not signed or signature is invalid."
+            exit 1
+          fi
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+
       - name: Build tarball
         run: make tarball
+
+      - name: Store release version
+        id: version
+        run: |
+          version="$(git describe --tags)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Upload Tarball as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-tarball
-          path: ./xext-rexsec-${{ github.ref_name }}.tar.gz
+          path: ./xext-rexsec-${{ steps.version.outputs.version }}.tar.gz
           retention-days: 1
 
   release:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Force fetch annotated tags
-        run: git fetch --tags --force
-
       - name: Download Tarball
         uses: actions/download-artifact@v4
         with:
           name: release-tarball
 
-      - name: Import Public Key
-        run: |
-          echo "${{ secrets.GPG_PUBLIC_KEY }}" | gpg --import
-
-      - name: Verify Signature
-        run: |
-          if ! git verify-tag ${{ github.ref_name }}; then
-            echo "Error: Tag is not signed or signature is invalid."
-            exit 1
-          fi
-
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
-          gh release create ${{ github.ref_name }} ./xext-rexsec-${{ github.ref_name }}.tar.gz \
-            --title "Release ${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" "./xext-rexsec-$VERSION.tar.gz" \
+            --title "Release $TAG_NAME" \
             --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,16 @@ xext-rexsec-%.tar.gz: $(SOURCES) VERSION
 	@test "$$(cat VERSION)" = "$*"
 	tar -czf $@ $^
 
-tarball: VERSION
-	@$(MAKE) xext-rexsec-$(shell cat VERSION).tar.gz
+check-release-tags:
+	@set -- $$($(GIT) tag --points-at HEAD); \
+	if [ "$$#" -gt 1 ]; then \
+		echo "Error: multiple tags point at HEAD:" >&2; \
+		printf '  %s\n' "$$@" >&2; \
+		exit 1; \
+	fi
+
+tarball: check-release-tags VERSION
+	@$(MAKE) xext-rexsec-$$(cat VERSION).tar.gz
 
 install: rexsec.so
 	install -m644 -pD rexsec.so $(DESTDIR)$(XORGEXTDIR)/rexsec.so
@@ -47,4 +55,4 @@ clean:
 distclean: clean
 	-rm rexsec.so
 
-.PHONY: all clean distclean install tarball
+.PHONY: all check-release-tags clean distclean install tarball


### PR DESCRIPTION
Verify release tags before building and keep tarball naming based on git describe while rejecting ambiguous HEAD tags.

Assisted-by: OpenAI Codex